### PR TITLE
Fixes bug with white bottom widget

### DIFF
--- a/gtkrc
+++ b/gtkrc
@@ -44,7 +44,7 @@ style "bottom"
 }
 
 widget "lxdm" style "back"
-widget "lxdm.*.time" style "time"
-widget "lxdm.*.prompt" style "prompt"
-widget "lxdm.*.bottom_pane" style "bottom"
+widget "*.time" style "time"
+widget "lxdm.prompt" style "prompt"
+widget "*.bottom_pane" style "bottom"
 widget_class "GtkWindow.*.GtkEventBox.*.<GtkLabel>" style "bottom"


### PR DESCRIPTION
https://sourceforge.net/p/lxde/bugs/921/
LXDM with gtk_theme=Adwaita and theme=IndustrialArch with glib2-2.58.3 looks differently than with 2.60.0. In 2.58 the bottom widget for selecting environement and computer stopping/restarting is black, while in 2.60 it's white.
This PR makes the bottom widget black/transparent again.